### PR TITLE
Rel 0.0.1 version bump & CHANGELOG update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
-## v0.0.1 - 2022-??-?? - In the beginning
+## v0.0.1 - 2022-10-10 - In the beginning
 
 * Initial extraction of octodns.axfr.* from octoDNS core
+* Support for RFC 2631 record updates, making this capable of fully managing DNS
+  servers that support it (and AXFR.)


### PR DESCRIPTION
## v0.0.1 - 2022-10-10 - In the beginning

* Initial extraction of octodns.axfr.* from octoDNS core
* Support for RFC 2631 record updates, making this capable of fully managing DNS
  servers that support it (and AXFR.)