### PR TITLE
Fix file_extension documentation and raise exception when zonefile not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ providers:
       # File extension on zone files
       # Appended to zone name to locate file
       # (optional, default None)
-      file_extension: zone
+      file_extension: .zone
       # Should sanity checks of the origin node be done
       # (optional, default true)
       check_origin: false

--- a/tests/test_provider_octodns_bind.py
+++ b/tests/test_provider_octodns_bind.py
@@ -19,6 +19,7 @@ from octodns_bind import (
     Rfc2136Provider,
     ZoneFileSource,
     ZoneFileSourceLoadFailure,
+    ZoneFileSourceNotFound,
 )
 
 
@@ -62,6 +63,17 @@ class TestAxfrSource(TestCase):
 class TestZoneFileSource(TestCase):
     source = ZoneFileSource('test', './tests/zones', file_extension='.tst')
 
+    def test_zonefile_not_found(self):
+        with self.assertRaises(ZoneFileSourceNotFound) as ctx:
+            source = ZoneFileSource('notfound', './tests/zones')
+            notfound = Zone('not.found.', [])
+            source.populate(notfound)
+
+        self.assertEqual(
+            'Zone file not found at ./tests/zones/not.found.',
+            str(ctx.exception),
+        )
+
     def test_zonefiles_with_extension(self):
         source = ZoneFileSource('test', './tests/zones', '.extension')
         # Load zonefiles with a specified file extension
@@ -104,11 +116,6 @@ class TestZoneFileSource(TestCase):
 
         # bust the cache
         del self.source._zone_records[valid.name]
-
-        # No zone file in directory
-        missing = Zone('missing.zone.', [])
-        self.source.populate(missing)
-        self.assertEqual(0, len(missing.records))
 
         # Zone file is not valid
         with self.assertRaises(ZoneFileSourceLoadFailure) as ctx:


### PR DESCRIPTION
Addresses #4 

* Fix README to show need for `.` in file extension
* Raise exception when zone file could not be found