### PR TITLE
Fix Rfc2136Provider example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Both allow transfer
 providers:
   rfc2136:
       # also available as octodns_bind.BindProvider
-      class: octodns_bind.Rfc2136
+      class: octodns_bind.Rfc2136Provider
       # The address of nameserver to perform zone transfer against
       host: ns1.example.com
       # optional, default: non-authed


### PR DESCRIPTION
The example for RFC 2136 has the wrong class, resulting in an error message:
```
octodns.manager.ManagerException: Unknown provider class: octodns_bind.Rfc2136
```