### PR TITLE
Raise exception and log an error if update fails

### DIFF
--- a/octodns_bind/__init__.py
+++ b/octodns_bind/__init__.py
@@ -190,6 +190,15 @@ class AxfrSource(AxfrPopulate, BaseSource):
     pass
 
 
+class Rfc2136ProviderException(Exception):
+    pass
+
+
+class Rfc2136ProviderUpdateFailed(Rfc2136ProviderException):
+    def __init__(self, err):
+        super().__init__(f'Unable to perform update: {err}')
+
+
 class Rfc2136Provider(AxfrPopulate, BaseProvider):
     '''
     RFC-2136 7.6: States it's not possible to create zones, so we'll assume they
@@ -218,12 +227,7 @@ class Rfc2136Provider(AxfrPopulate, BaseProvider):
 
         r: dns.message.Message = dns.query.tcp(update, self.host)
         if r.rcode() != dns.rcode.NOERROR:
-            self.log.error(
-                f"Could not perform update: {dns.rcode.to_text(r.rcode())}"
-            )
-            raise Exception(
-                f"Could not perform update: {dns.rcode.to_text(r.rcode())}"
-            )
+            raise Rfc2136ProviderUpdateFailed(dns.rcode.to_text(r.rcode()))
 
         self.log.debug(
             '_apply: zone=%s, num_records=%d', name, len(plan.changes)

--- a/octodns_bind/__init__.py
+++ b/octodns_bind/__init__.py
@@ -218,7 +218,8 @@ class Rfc2136Provider(AxfrPopulate, BaseProvider):
 
         r: dns.message.Message = dns.query.tcp(update, self.host)
         if r.rcode() != dns.rcode.NOERROR:
-            raise Exception(f"Could not perform update: {r}")
+            self.log.error(f"Could not perform update: {r.rcode()}")
+            raise Exception(f"Could not perform update: {r.rcode()}")
 
         self.log.debug(
             '_apply: zone=%s, num_records=%d', name, len(plan.changes)

--- a/octodns_bind/__init__.py
+++ b/octodns_bind/__init__.py
@@ -218,8 +218,12 @@ class Rfc2136Provider(AxfrPopulate, BaseProvider):
 
         r: dns.message.Message = dns.query.tcp(update, self.host)
         if r.rcode() != dns.rcode.NOERROR:
-            self.log.error(f"Could not perform update: {r.rcode()}")
-            raise Exception(f"Could not perform update: {r.rcode()}")
+            self.log.error(
+                f"Could not perform update: {dns.rcode.to_text(r.rcode())}"
+            )
+            raise Exception(
+                f"Could not perform update: {dns.rcode.to_text(r.rcode())}"
+            )
 
         self.log.debug(
             '_apply: zone=%s, num_records=%d', name, len(plan.changes)

--- a/octodns_bind/__init__.py
+++ b/octodns_bind/__init__.py
@@ -216,7 +216,9 @@ class Rfc2136Provider(AxfrPopulate, BaseProvider):
             else:  # isinstance(change, Delete):
                 update.delete(name, _type, *rdatas)
 
-        dns.query.tcp(update, self.host)
+        r: dns.message.Message = dns.query.tcp(update, self.host)
+        if r.rcode() != dns.rcode.NOERROR:
+            raise Exception(f"Could not perform update: {r}")
 
         self.log.debug(
             '_apply: zone=%s, num_records=%d', name, len(plan.changes)

--- a/tests/test_provider_octodns_bind.py
+++ b/tests/test_provider_octodns_bind.py
@@ -17,6 +17,7 @@ from octodns_bind import (
     AxfrSource,
     AxfrSourceZoneTransferFailed,
     Rfc2136Provider,
+    Rfc2136ProviderUpdateFailed,
     ZoneFileSource,
     ZoneFileSourceLoadFailure,
 )
@@ -195,7 +196,7 @@ class TestRfc2136Provider(TestCase):
         ]
         plan = provider.plan(desired)
         self.assertTrue(plan)
-        self.assertRaises(Exception, provider.apply, plan)
+        self.assertRaises(Rfc2136ProviderUpdateFailed, provider.apply, plan)
         dns_query_tcp_mock.assert_called_once()
         replace_mock.assert_called_with('a.unit.tests.', 42, 'A', '1.2.3.4')
         add_mock.assert_not_called()

--- a/tests/test_provider_octodns_bind.py
+++ b/tests/test_provider_octodns_bind.py
@@ -172,6 +172,7 @@ class TestRfc2136Provider(TestCase):
             add_mock.reset_mock()
             replace_mock.reset_mock()
             delete_mock.reset_mock()
+            dns_query_tcp_mock.return_value = dns.message.Message()
 
         # create
         reset()
@@ -182,6 +183,22 @@ class TestRfc2136Provider(TestCase):
         dns_query_tcp_mock.assert_called_once()
         add_mock.assert_called_with('a.unit.tests.', 42, 'A', '1.2.3.4')
         replace_mock.assert_not_called()
+        delete_mock.assert_not_called()
+
+        # update with error
+        reset()
+        error_result = dns.message.Message()
+        error_result.set_rcode(dns.rcode.REFUSED)
+        dns_query_tcp_mock.return_value = error_result
+        zone_records_mock.side_effect = [
+            [Rr('a.unit.tests.', 'A', 42, '2.3.4.5')]
+        ]
+        plan = provider.plan(desired)
+        self.assertTrue(plan)
+        self.assertRaises(Exception, provider.apply, plan)
+        dns_query_tcp_mock.assert_called_once()
+        replace_mock.assert_called_with('a.unit.tests.', 42, 'A', '1.2.3.4')
+        add_mock.assert_not_called()
         delete_mock.assert_not_called()
 
         # update


### PR DESCRIPTION
If BIND is unable to perform an update it returns something other then NOERROR.
This patch requests implements the detection of an negative returncode and raises an exception after logging the error