### PR TITLE
AxfrPopulate: Add key_algorithm option

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ providers:
       key_name: env/AXFR_KEY_NAME
       # optional, default: non-authed
       key_secret: env/AXFR_KEY_SECRET
+      # optional, see https://github.com/rthalley/dnspython/blob/master/dns/tsig.py#L78
+      # for available algorithms
+      key_algorithm: hmac-sha1
 ```
 
 See below for example Bind9 server configuration. Any server that supports RFC
@@ -93,6 +96,9 @@ providers:
       key_name: env/AXFR_KEY_NAME
       # optional, default: non-authed
       key_secret: env/AXFR_KEY_SECRET
+      # optional, see https://github.com/rthalley/dnspython/blob/master/dns/tsig.py#L78
+      # for available algorithms
+      key_algorithm: hmac-sha1
 ```
 
 Example Bind9 config to enable AXFR and RFC 2136

--- a/octodns_bind/__init__.py
+++ b/octodns_bind/__init__.py
@@ -142,7 +142,9 @@ class AxfrSourceZoneTransferFailed(AxfrSourceException):
 
 
 class AxfrPopulate(RfcPopulate):
-    def __init__(self, id, host, key_name=None, key_secret=None, key_algorithm=None):
+    def __init__(
+        self, id, host, key_name=None, key_secret=None, key_algorithm=None
+    ):
         self.log = getLogger(f'{self.__class__.__name__}[{id}]')
         self.log.debug(
             '__init__: id=%s, host=%s, key_name=%s, key_secret=%s',

--- a/octodns_bind/__init__.py
+++ b/octodns_bind/__init__.py
@@ -155,7 +155,7 @@ class AxfrPopulate(RfcPopulate):
         self.host = host
         self.key_name = key_name
         self.key_secret = key_secret
-        self.key_algorithm = key_secret
+        self.key_algorithm = key_algorithm
 
     def _auth_params(self):
         params = {}

--- a/octodns_bind/__init__.py
+++ b/octodns_bind/__init__.py
@@ -142,7 +142,7 @@ class AxfrSourceZoneTransferFailed(AxfrSourceException):
 
 
 class AxfrPopulate(RfcPopulate):
-    def __init__(self, id, host, key_name=None, key_secret=None):
+    def __init__(self, id, host, key_name=None, key_secret=None, key_algorithm=None):
         self.log = getLogger(f'{self.__class__.__name__}[{id}]')
         self.log.debug(
             '__init__: id=%s, host=%s, key_name=%s, key_secret=%s',
@@ -155,6 +155,7 @@ class AxfrPopulate(RfcPopulate):
         self.host = host
         self.key_name = key_name
         self.key_secret = key_secret
+        self.key_algorithm = key_secret
 
     def _auth_params(self):
         params = {}
@@ -162,6 +163,8 @@ class AxfrPopulate(RfcPopulate):
             params['keyring'] = tsigkeyring.from_text(
                 {self.key_name: self.key_secret}
             )
+        if self.key_algorithm is not None:
+            params['keyalgorithm'] = self.key_algorithm
         return params
 
     def zone_records(self, zone):

--- a/octodns_bind/__init__.py
+++ b/octodns_bind/__init__.py
@@ -137,8 +137,8 @@ class AxfrSourceException(Exception):
 
 
 class AxfrSourceZoneTransferFailed(AxfrSourceException):
-    def __init__(self):
-        super().__init__('Unable to Perform Zone Transfer')
+    def __init__(self, err):
+        super().__init__(f'Unable to Perform Zone Transfer: {err}')
 
 
 class AxfrPopulate(RfcPopulate):
@@ -178,8 +178,8 @@ class AxfrPopulate(RfcPopulate):
                 ),
                 relativize=False,
             )
-        except DNSException:
-            raise AxfrSourceZoneTransferFailed()
+        except DNSException as err:
+            raise AxfrSourceZoneTransferFailed(err) from None
 
         records = []
 

--- a/tests/test_provider_octodns_bind.py
+++ b/tests/test_provider_octodns_bind.py
@@ -141,9 +141,14 @@ class TestRfc2136Provider(TestCase):
 
         key_secret = 'vZew5TtZLTZKTCl00xliGt+1zzsuLWQWFz48bRbPnZU='
         provider = Rfc2136Provider(
-            'test', 'localhost', key_name='key-name', key_secret=key_secret
+            'test',
+            'localhost',
+            key_name='key-name',
+            key_secret=key_secret,
+            key_algorithm='hmac-sha1',
         )
         self.assertTrue('keyring' in provider._auth_params())
+        self.assertTrue('keyalgorithm' in provider._auth_params())
 
     @patch('dns.update.Update.delete')
     @patch('dns.update.Update.replace')

--- a/tests/test_provider_octodns_bind.py
+++ b/tests/test_provider_octodns_bind.py
@@ -47,7 +47,10 @@ class TestAxfrSource(TestCase):
         with self.assertRaises(AxfrSourceZoneTransferFailed) as ctx:
             zone = Zone('unit.tests.', [])
             self.source.populate(zone)
-        self.assertEqual('Unable to Perform Zone Transfer', str(ctx.exception))
+        self.assertEqual(
+            'Unable to Perform Zone Transfer',
+            str(ctx.exception).split(':', 1)[0],
+        )
 
     @patch('dns.zone.from_xfr')
     def test_populate_reverse(self, from_xfr_mock):


### PR DESCRIPTION
Add option key_algorithm to AxfrPopulate. 
This seems to be needed at least for md5 `(HMAC-MD5.SIG-ALG.REG.INT)`