### PR TITLE
v0.0.2 version bump and changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.0.2 - 2023-04-05 - Ports and Crypto
+
+- Add port parameter to AXFR source and RFC2136 provider.
+- Add key_algorithm parameter for TSIG
+- Error when RFC2136 provider is unable to perform an update
+
 ## v0.0.1 - 2022-10-10 - In the beginning
 
 * Initial extraction of octodns.axfr.* from octoDNS core

--- a/octodns_bind/__init__.py
+++ b/octodns_bind/__init__.py
@@ -18,7 +18,7 @@ from octodns.provider.base import BaseProvider
 from octodns.record import Create, Record, Rr, Update
 from octodns.source.base import BaseSource
 
-__VERSION__ = '0.0.1'
+__VERSION__ = '0.0.2'
 
 
 class RfcPopulate:


### PR DESCRIPTION
```
## v0.0.2 - 2023-04-05 - Ports and Crypto

- Add port parameter to AXFR source and RFC2136 provider.
- Add key_algorithm parameter for TSIG
- Error when RFC2136 provider is unable to perform an update
```