### PR TITLE
force port to be cast to an int #17

### DIFF
--- a/octodns_bind/__init__.py
+++ b/octodns_bind/__init__.py
@@ -163,7 +163,7 @@ class AxfrPopulate(RfcPopulate):
         )
         super().__init__(id)
         self.host = host
-        self.port = port
+        self.port = int(port)
         self.key_name = key_name
         self.key_secret = key_secret
         self.key_algorithm = key_algorithm


### PR DESCRIPTION
Fixes #17 

Cast port to int, so that if it's an int it will stay an int, if it's a string it will be cast to an int (this is the case when it's passed via environment variable in the config)

@Marthym