### PR TITLE
Resolve AXFR host if DNS name is supplied

### DIFF
--- a/octodns_bind/__init__.py
+++ b/octodns_bind/__init__.py
@@ -9,6 +9,7 @@ from os.path import join
 import dns.name
 import dns.query
 import dns.rdatatype
+import dns.resolver
 import dns.zone
 from dns import tsigkeyring
 from dns.exception import DNSException
@@ -162,11 +163,24 @@ class AxfrPopulate(RfcPopulate):
             key_algorithm is not None,
         )
         super().__init__(id)
-        self.host = host
+        self.host = self._host(host)
         self.port = int(port)
         self.key_name = key_name
         self.key_secret = key_secret
         self.key_algorithm = key_algorithm
+
+    def _host(self, host):
+        h = host
+        try:
+            # Determine if IPv4/IPv6 address
+            dns.inet.af_for_address(host)
+        except ValueError:
+            try:
+                h = dns.resolver.resolve(host)[0].address
+            except DNSException as err:
+                raise AxfrSourceZoneTransferFailed(err) from None
+
+        return h
 
     def _auth_params(self):
         params = {}

--- a/tests/test_provider_octodns_bind.py
+++ b/tests/test_provider_octodns_bind.py
@@ -7,6 +7,7 @@ from shutil import copyfile
 from unittest import TestCase
 from unittest.mock import patch
 
+import dns.resolver
 import dns.zone
 from dns.exception import DNSException
 
@@ -139,6 +140,27 @@ class TestZoneFileSource(TestCase):
 
 
 class TestRfc2136Provider(TestCase):
+    def test_host_ip(self):
+        provider = Rfc2136Provider('test', '192.0.2.1')
+        self.assertEqual('192.0.2.1', provider.host)
+
+    @patch('dns.resolver.resolve')
+    def test_host_dns(self, resolve_mock):
+        host, ip = 'axfr.unit.tests.', '192.0.2.2'
+
+        # Query success
+        resolve_mock.return_value = dns.rrset.from_text(
+            host, 300, 'IN', 'A', ip
+        )
+        provider = Rfc2136Provider('test', host)
+        self.assertEqual(ip, provider.host)
+
+        # Query failure
+        resolve_mock.reset_mock()
+        resolve_mock.side_effect = DNSException
+        with self.assertRaises(AxfrSourceZoneTransferFailed):
+            provider = Rfc2136Provider('test', host)
+
     def test_auth(self):
         provider = Rfc2136Provider('test', 'localhost')
         self.assertEqual({}, provider._auth_params())


### PR DESCRIPTION
Addresses #18 

In our documentation we reference using a DNS name, which actually was not functional and wildly it never came up until recently. dnspython's `dns.query.xfr` and `dns.query.tcp` expect an IP address to perform actions against otherwise it will error, it does not handle resolving it on it's own.

This change adds a quick check to see if the host supplied by the user is an IPv4/IPv6 addresses or a DNS name, and if a DNS name is supplied it will resolve it to an IP to be passed off to `dns.query.xfr` and `dns.query.tcp`

Probably after #5 and this are merged will cut a new release
