### PR TITLE
v0.0.3 version bump and changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.0.3 - 2023-05-14 - TSLA, Error, and DNS host
+
+- Host can be a DNS name or an IP address
+- ZoneFileSource will error if file is not found
+- Support for TLSA records
+
 ## v0.0.2 - 2023-04-05 - Ports and Crypto
 
 - Add port parameter to AXFR source and RFC2136 provider.

--- a/octodns_bind/__init__.py
+++ b/octodns_bind/__init__.py
@@ -19,7 +19,7 @@ from octodns.provider.base import BaseProvider
 from octodns.record import Create, Record, Rr, Update
 from octodns.source.base import BaseSource
 
-__VERSION__ = '0.0.2'
+__VERSION__ = '0.0.3'
 
 
 class RfcPopulate:


### PR DESCRIPTION
## v0.0.3 - 2023-05-14 - TSLA, Error, and DNS host

- Host can be a DNS name or an IP address
- ZoneFileSource will error if file is not found
- Support for TLSA records (@kompetenzbolzen)