### PR TITLE
Ignore quotes when checking invalid record assertion

### DIFF
--- a/tests/test_provider_octodns_bind.py
+++ b/tests/test_provider_octodns_bind.py
@@ -134,10 +134,12 @@ class TestZoneFileSource(TestCase):
         with self.assertRaises(ValidationError) as ctx:
             zone = Zone('invalid.records.', [])
             self.source.populate(zone)
+        # quotes were added to the record name 1.0.0rc1, this makes it work with
+        # both version
+        reason = str(ctx.exception).replace('"', '')
         self.assertEqual(
-            'Invalid record _invalid.invalid.records.\n'
-            '  - invalid name for SRV record',
-            str(ctx.exception),
+            'Invalid record _invalid.invalid.records.\n  - invalid name for SRV record',
+            reason,
         )
 
         # Records are not to RFC, but load anyhow (lenient=True)


### PR DESCRIPTION
https://github.com/octodns/octodns/issues/1003 adds quotes to the exception message for invalid records around the name, to make it more clear exactly what the name is and thus why it's failing. 

There's a test in this repo that looks for an exact string match which that causes to fail https://github.com/octodns/octodns/actions/runs/5026727394/jobs/9015343601?pr=1004.

This PR makes a simple change to remove the `"` during the test/check so that it works with version before and after the change.