### PR TITLE
refactor _host to use getaddrinfo instead of dns.resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,10 @@ providers:
       host: ns1.example.com
       # The port that the nameserver is listening on. Optional. Default: 53
       port: 53
-      # optional, default: False
+      # Use IPv6 to perform operations. Optional. Default: False
       ipv6: False
+      # The number of seconds to wait until timing out. Optional. Default: 15
+      timeout: 15
       # optional, default: non-authed
       key_name: env/AXFR_KEY_NAME
       # optional, default: non-authed
@@ -98,8 +100,10 @@ providers:
       host: ns1.example.com
       # The port that the nameserver is listening on. Optional. Default: 53
       port: 53
-      # optional, default: False
+      # Use IPv6 to perform operations. Optional. Default: False
       ipv6: False
+      # The number of seconds to wait until timing out. Optional. Default: 15
+      timeout: 15
       # optional, default: non-authed
       key_name: env/AXFR_KEY_NAME
       # optional, default: non-authed

--- a/README.md
+++ b/README.md
@@ -146,4 +146,25 @@ This module does not support dynamic records.
 
 See the [/script/](/script/) directory for some tools to help with the development process. They generally follow the [Script to rule them all](https://github.com/github/scripts-to-rule-them-all) pattern. Most useful is `./script/bootstrap` which will create a venv and install both the runtime and development related requirements. It will also hook up a pre-commit hook that covers most of what's run by CI.
 
-There is a [docker-compose.yml](/docker-compose.yml) file included in the repo that will set up a Bind9 server with AXFR transfers and RFC 2136 updates enabled for use in development. The secret for the server can be found in [docker/etc/bind/named.conf](docker/etc/bind/named.conf).
+#### Local Server
+
+A local server is included in the repo via [docker-compose.yml](/docker-compose.yml). This will set up a Bind9 server with AXFR transfers and RFC 2136 updates enabled for use in development on IPv4 and IPv6. Configuration for the server can be found in [docker/etc/bind/named.conf](docker/etc/bind/named.conf), including the TSIG secret which can be used to perform authenticated operations. Zonefiles can be found in [docker/var/lib/bind](docker/var/lib/bind). All logs are written to STDOUT and can be viewed by running `docker-compose logs -f`
+
+An example octodns configuration to interact with the local server is below:
+
+```yaml
+providers:
+  rfc2136:
+    class: octodns_bind.Rfc2136Provider
+    host: localhost
+    key_name: 'octodns.exxampled.com.'
+    key_secret: 'vZew5TtZLTZKTCl00xliGt+1zzsuLWQWFz48bRbPnZU='
+    key_algorithm: 'hmac-sha256'
+
+zones:
+  exxampled.com.:
+    sources:
+      - config
+    targets:
+      - rfc2136
+```

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ providers:
       host: ns1.example.com
       # The port that the nameserver is listening on. Optional. Default: 53
       port: 53
+      # optional, default: False
+      ipv6: False
       # optional, default: non-authed
       key_name: env/AXFR_KEY_NAME
       # optional, default: non-authed
@@ -96,6 +98,8 @@ providers:
       host: ns1.example.com
       # The port that the nameserver is listening on. Optional. Default: 53
       port: 53
+      # optional, default: False
+      ipv6: False
       # optional, default: non-authed
       key_name: env/AXFR_KEY_NAME
       # optional, default: non-authed

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.9"  # optional since v1.27.0
+version: "2.4"  # optional since v1.27.0
 
 services:
   bind9:
@@ -8,6 +8,8 @@ services:
       - 53:53/tcp
       - 53:53/udp
       - 953:953/tcp
+    networks:
+      - dns
     volumes:
       - type: bind
         source: ./docker/etc/bind/named.conf
@@ -15,3 +17,10 @@ services:
       - type: bind
         source: ./docker/var/lib/bind/db.exxampled.com
         target: /var/lib/bind/db.exxampled.com
+networks:
+  dns:
+    enable_ipv6: true
+    ipam:
+      config:
+        - subnet: 192.0.2.0/24
+        - subnet: 2001:db8::/32

--- a/docker/etc/bind/named.conf
+++ b/docker/etc/bind/named.conf
@@ -26,3 +26,35 @@ zone "exxampled.com." {
   allow-transfer { key octodns.exxampled.com.; };
   allow-update { key octodns.exxampled.com.; };
 };
+
+# logging
+logging {
+  channel stdout {
+      stderr;
+      severity info;
+      print-category no;
+      print-severity no;
+      print-time yes;
+  };
+  category security { stdout; };
+  category dnssec   { stdout; };
+  category default  { stdout; };
+  category queries  { stdout; };
+  category client { stdout; };
+  category config { stdout; };
+  category database { stdout; };
+  category default { stdout; };
+  category dispatch { stdout; };
+  category dnssec { stdout; };
+  category general { stdout; };
+  category lame-servers { stdout; };
+  category network { stdout; };
+  category notify { stdout; };
+  category queries { stdout; };
+  category resolver { stdout; };
+  category security { stdout; };
+  category unmatched { stdout; };
+  category update { stdout; };
+  category xfer-in { stdout; };
+  category xfer-out { stdout; };
+};

--- a/octodns_bind/__init__.py
+++ b/octodns_bind/__init__.py
@@ -2,6 +2,7 @@
 #
 #
 
+import socket
 from logging import getLogger
 from os import listdir
 from os.path import join
@@ -147,37 +148,44 @@ class AxfrPopulate(RfcPopulate):
         id,
         host,
         port=53,
+        ipv6=False,
         key_name=None,
         key_secret=None,
         key_algorithm=None,
     ):
         self.log = getLogger(f'{self.__class__.__name__}[{id}]')
         self.log.debug(
-            '__init__: id=%s, host=%s, port=%d, key_name=%s, key_secret=%s, key_algorithm=%s',
+            '__init__: id=%s, host=%s, port=%d, ipv6=%s, key_name=%s, key_secret=%s, key_algorithm=%s',
             id,
             host,
             port,
+            ipv6,
             key_name,
             key_secret is not None,
             key_algorithm is not None,
         )
         super().__init__(id)
-        self.host = self._host(host)
+        self.host = self._host(host, ipv6)
         self.port = int(port)
+        self.ipv6 = ipv6
         self.key_name = key_name
         self.key_secret = key_secret
         self.key_algorithm = key_algorithm
 
-    def _host(self, host):
+    def _host(self, host, ipv6):
         h = host
         try:
             # Determine if IPv4/IPv6 address
             dns.inet.af_for_address(host)
         except ValueError:
+            address_family = socket.AF_INET
+            if ipv6:
+                address_family = socket.AF_INET6
+
             try:
-                h = dns.resolver.resolve(host)[0].address
-            except DNSException as err:
-                raise AxfrSourceZoneTransferFailed(err) from None
+                h = socket.getaddrinfo(host, None, address_family)[0][4][0]
+            except OSError as err:
+                raise AxfrSourceZoneTransferFailed(err)
 
         return h
 

--- a/octodns_bind/__init__.py
+++ b/octodns_bind/__init__.py
@@ -149,17 +149,19 @@ class AxfrPopulate(RfcPopulate):
         host,
         port=53,
         ipv6=False,
+        timeout=15,
         key_name=None,
         key_secret=None,
         key_algorithm=None,
     ):
         self.log = getLogger(f'{self.__class__.__name__}[{id}]')
         self.log.debug(
-            '__init__: id=%s, host=%s, port=%d, ipv6=%s, key_name=%s, key_secret=%s, key_algorithm=%s',
+            '__init__: id=%s, host=%s, port=%d, ipv6=%s, timeout=%d, key_name=%s, key_secret=%s, key_algorithm=%s',
             id,
             host,
             port,
             ipv6,
+            timeout,
             key_name,
             key_secret is not None,
             key_algorithm is not None,
@@ -168,6 +170,7 @@ class AxfrPopulate(RfcPopulate):
         self.host = self._host(host, ipv6)
         self.port = int(port)
         self.ipv6 = ipv6
+        self.timeout = float(timeout)
         self.key_name = key_name
         self.key_secret = key_secret
         self.key_algorithm = key_algorithm
@@ -207,6 +210,8 @@ class AxfrPopulate(RfcPopulate):
                     self.host,
                     zone.name,
                     port=self.port,
+                    timeout=self.timeout,
+                    lifetime=self.timeout,
                     relativize=False,
                     **auth_params,
                 ),
@@ -265,7 +270,7 @@ class Rfc2136Provider(AxfrPopulate, BaseProvider):
                 update.delete(name, _type, *rdatas)
 
         r: dns.message.Message = dns.query.tcp(
-            update, self.host, port=self.port
+            update, self.host, port=self.port, timeout=self.timeout
         )
         if r.rcode() != dns.rcode.NOERROR:
             raise Rfc2136ProviderUpdateFailed(dns.rcode.to_text(r.rcode()))


### PR DESCRIPTION
Follow up to #27 which is about #24 #25

`dns.resolver.resolve()` does not look at the normal chain of things (`/etc/hosts`, ``etc`` when resolving a DNS name so there can be cases when things like `localhost` do not resolve, or when a user configured something in `/etc/hosts` would not work.

By using `socket.getaddrinfo` we can support IPv4/IPv6 as well as have the lookup go through the normal chain of things.