### PR TITLE
v0.0.4 version bump and changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.0.4 - 2023-05-23 - First Stop /etc/hosts
+
+- Use socket.gethostaddr instead of dns.resolver.resolve to look up host
+- Add timeout for zone transfers and updates
+
 ## v0.0.3 - 2023-05-14 - TSLA, Error, and DNS host
 
 - Host can be a DNS name or an IP address

--- a/octodns_bind/__init__.py
+++ b/octodns_bind/__init__.py
@@ -20,7 +20,7 @@ from octodns.provider.base import BaseProvider
 from octodns.record import Create, Record, Rr, Update
 from octodns.source.base import BaseSource
 
-__VERSION__ = '0.0.3'
+__VERSION__ = '0.0.4'
 
 
 class RfcPopulate:


### PR DESCRIPTION
## v0.0.4 - 2023-05-23 - First Stop /etc/hosts

- Use socket.gethostaddr instead of dns.resolver.resolve to look up host #27 
- Add timeout for zone transfers and updates #28 