### PR TITLE
ZoneFileSource.list_zones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.0.5 - 2023-??-?? - ???
+
+- ZoneFileSource.list_zones added to support dynamic zone config
+
 ## v0.0.4 - 2023-05-23 - First Stop /etc/hosts
 
 - Use socket.gethostaddr instead of dns.resolver.resolve to look up host

--- a/octodns_bind/__init__.py
+++ b/octodns_bind/__init__.py
@@ -97,6 +97,14 @@ class ZoneFileSource(RfcPopulate, BaseSource):
 
         self._zone_records = {}
 
+    def list_zones(self):
+        n = len(self.file_extension) - 1
+        for filename in sorted(listdir(self.directory)):
+            if filename.endswith(self.file_extension):
+                if n > 0:
+                    filename = filename[:-n]
+                yield filename
+
     def _load_zone_file(self, zone_name):
         zone_filename = f'{zone_name[:-1]}{self.file_extension}'
         zonefiles = listdir(self.directory)

--- a/tests/test_provider_octodns_bind.py
+++ b/tests/test_provider_octodns_bind.py
@@ -148,6 +148,18 @@ class TestZoneFileSource(TestCase):
         self.source.populate(invalid, lenient=True)
         self.assertEqual(12, len(invalid.records))
 
+    def test_list_zones(self):
+        source = ZoneFileSource('test', './tests/zones', file_extension='.tst')
+        self.assertEqual(
+            ['invalid.records.', 'invalid.zone.', 'unit.tests.'],
+            list(source.list_zones()),
+        )
+
+        source = ZoneFileSource('test', './tests/zones')
+        self.assertEqual(
+            ['2.0.192.in-addr.arpa.', 'unit.tests.'], list(source.list_zones())
+        )
+
 
 class TestRfc2136Provider(TestCase):
     def test_host_ip(self):


### PR DESCRIPTION
Implements list_zones for ZoneFileSource. 

Unfortunately there doesn't seem to be a way to remotely get a list of zones from a running bind server (via AXFR like queries) so no such support for AxfrSource.

/cc https://github.com/octodns/octodns/pull/1026