### PR TITLE
ZoneFileProvider, read and write support added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## v0.0.5 - 2023-??-?? - ???
 
+- ZoneFileProvider, full support writing zone files out to disk
 - ZoneFileSource.list_zones added to support dynamic zone config
 
 ## v0.0.4 - 2023-05-23 - First Stop /etc/hosts

--- a/octodns_bind/__init__.py
+++ b/octodns_bind/__init__.py
@@ -272,16 +272,19 @@ class ZoneFileProvider(RfcPopulate, BaseProvider):
                 except AttributeError:
                     values = [record.value]
                 for value in values:
+                    if record._type == 'TXT':
+                        # TXT values need to be quoted
+                        value = f'"{value.rdata_text}"'
+                    else:
+                        value = value.rdata_text
                     name = '@' if record.name == '' else record.name
                     if name == prev_name:
                         name = ''
                     else:
                         prev_name = name
                     fh.write(
-                        f'{name:<{longest_name}} {record.ttl:8d} IN {record._type:<8} '
+                        f'{name:<{longest_name}} {record.ttl:8d} IN {record._type:<8} {value}\n'
                     )
-                    fh.write(value.rdata_text)
-                    fh.write('\n')
 
         self.log.debug(
             '_apply: zone=%s, num_records=%d', name, len(plan.changes)

--- a/octodns_bind/__init__.py
+++ b/octodns_bind/__init__.py
@@ -6,7 +6,7 @@ import socket
 from datetime import datetime
 from logging import getLogger
 from os import listdir, makedirs
-from os.path import isdir, join
+from os.path import exists, isdir, join
 from string import Template
 
 import dns.name
@@ -66,8 +66,7 @@ class RfcPopulate:
             'populate:   found %s records', len(zone.records) - before
         )
 
-        # TODO: how do we do exists
-        return True
+        return self.zone_exists(zone)
 
 
 class ZoneFileSourceException(Exception):
@@ -199,6 +198,10 @@ class ZoneFileProvider(RfcPopulate, BaseProvider):
             raise ZoneFileSourceNotFound(path)
 
         return z
+
+    def zone_exists(self, zone):
+        zone_filename = f'{zone.name[:-1]}{self.file_extension}'
+        return exists(join(self.directory, zone_filename))
 
     def zone_records(self, zone, target):
         if zone.name not in self._zone_records:
@@ -391,6 +394,10 @@ class AxfrPopulate(RfcPopulate):
         if self.key_algorithm is not None:
             params['keyalgorithm'] = self.key_algorithm
         return params
+
+    def zone_exists(self, zone):
+        # We can't create them so they have to already exist
+        return True
 
     def zone_records(self, zone, target):
         auth_params = self._auth_params()

--- a/octodns_bind/__init__.py
+++ b/octodns_bind/__init__.py
@@ -118,6 +118,13 @@ class ZoneFileProvider(RfcPopulate, BaseProvider):
         # replaced with a `.`.
         # (default: webmaster)
         hostmaster_email: webmaster
+
+        # The details of the SOA record can be customized when creating
+        # zonefiles with the following options.
+        refresh: 3600
+        retry: 600
+        expire: 604800
+        nxdomain: 3600
     '''
 
     def __init__(
@@ -127,21 +134,33 @@ class ZoneFileProvider(RfcPopulate, BaseProvider):
         file_extension='.',
         check_origin=True,
         hostmaster_email='webmaster',
+        refresh=3600,
+        retry=600,
+        expire=604800,
+        nxdomain=3600,
     ):
         self.log = getLogger(f'ZoneFileProvider[{id}]')
         self.log.debug(
-            '__init__: id=%s, directory=%s, file_extension=%s, check_origin=%s, hostmaster_email=%s',
+            '__init__: id=%s, directory=%s, file_extension=%s, check_origin=%s, hostmaster_email=%s, refresh=%d, retry=%d, expire=%d, nxdomain=%d',
             id,
             directory,
             file_extension,
             check_origin,
             hostmaster_email,
+            refresh,
+            retry,
+            expire,
+            nxdomain,
         )
         super().__init__(id)
         self.directory = directory
         self.file_extension = file_extension
         self.check_origin = check_origin
         self.hostmaster_email = hostmaster_email
+        self.refresh = refresh
+        self.retry = retry
+        self.expire = expire
+        self.nxdomain = nxdomain
 
         self._zone_records = {}
 
@@ -243,10 +262,10 @@ class ZoneFileProvider(RfcPopulate, BaseProvider):
 
 @ $default_ttl IN SOA $primary_nameserver $hostmaster_email (
     $serial ; Serial
-    3600       ; Refresh (1 hour)
-    600        ; Retry (10 minutes)
-    604800     ; Expire (1 week)
-    3600       ; NXDOMAIN ttl (1 hour)
+    $refresh ; Refresh (1 hour)
+    $retry ; Retry (10 minutes)
+    $expire ; Expire (1 week)
+    $nxdomain ; NXDOMAIN ttl (1 hour)
 )
 
 '''
@@ -261,6 +280,10 @@ class ZoneFileProvider(RfcPopulate, BaseProvider):
                         'zone_name': name,
                         'default_ttl': 3600,
                         'primary_nameserver': primary_nameserver,
+                        'refresh': self.refresh,
+                        'retry': self.retry,
+                        'expire': self.expire,
+                        'nxdomain': self.nxdomain,
                     }
                 )
             )

--- a/octodns_bind/__init__.py
+++ b/octodns_bind/__init__.py
@@ -272,11 +272,11 @@ class ZoneFileProvider(RfcPopulate, BaseProvider):
                 except AttributeError:
                     values = [record.value]
                 for value in values:
-                    if record._type == 'TXT':
+                    value = value.rdata_text
+                    if record._type in ('SPF', 'TXT'):
                         # TXT values need to be quoted
-                        value = f'"{value.rdata_text}"'
-                    else:
-                        value = value.rdata_text
+                        value = value.replace('"', '\\"')
+                        value = f'"{value}"'
                     name = '@' if record.name == '' else record.name
                     if name == prev_name:
                         name = ''

--- a/octodns_bind/__init__.py
+++ b/octodns_bind/__init__.py
@@ -121,6 +121,7 @@ class ZoneFileProvider(RfcPopulate, BaseProvider):
 
         # The details of the SOA record can be customized when creating
         # zonefiles with the following options.
+        default_ttl: 3600
         refresh: 3600
         retry: 600
         expire: 604800
@@ -134,6 +135,7 @@ class ZoneFileProvider(RfcPopulate, BaseProvider):
         file_extension='.',
         check_origin=True,
         hostmaster_email='webmaster',
+        default_ttl=3600,
         refresh=3600,
         retry=600,
         expire=604800,
@@ -141,12 +143,13 @@ class ZoneFileProvider(RfcPopulate, BaseProvider):
     ):
         self.log = getLogger(f'ZoneFileProvider[{id}]')
         self.log.debug(
-            '__init__: id=%s, directory=%s, file_extension=%s, check_origin=%s, hostmaster_email=%s, refresh=%d, retry=%d, expire=%d, nxdomain=%d',
+            '__init__: id=%s, directory=%s, file_extension=%s, check_origin=%s, hostmaster_email=%s, default_ttl=%d, refresh=%d, retry=%d, expire=%d, nxdomain=%d',
             id,
             directory,
             file_extension,
             check_origin,
             hostmaster_email,
+            default_ttl,
             refresh,
             retry,
             expire,
@@ -157,6 +160,7 @@ class ZoneFileProvider(RfcPopulate, BaseProvider):
         self.file_extension = file_extension
         self.check_origin = check_origin
         self.hostmaster_email = hostmaster_email
+        self.default_ttl = default_ttl
         self.refresh = refresh
         self.retry = retry
         self.expire = expire
@@ -278,7 +282,7 @@ class ZoneFileProvider(RfcPopulate, BaseProvider):
                         'hostmaster_email': self._hostmaster_email(name),
                         'serial': self._serial(),
                         'zone_name': name,
-                        'default_ttl': 3600,
+                        'default_ttl': self.default_ttl,
                         'primary_nameserver': primary_nameserver,
                         'refresh': self.refresh,
                         'retry': self.retry,

--- a/octodns_bind/__init__.py
+++ b/octodns_bind/__init__.py
@@ -266,10 +266,10 @@ class ZoneFileProvider(RfcPopulate, BaseProvider):
 
 @ $default_ttl IN SOA $primary_nameserver $hostmaster_email (
     $serial ; Serial
-    $refresh ; Refresh (1 hour)
-    $retry ; Retry (10 minutes)
-    $expire ; Expire (1 week)
-    $nxdomain ; NXDOMAIN ttl (1 hour)
+    $refresh ; Refresh
+    $retry ; Retry
+    $expire ; Expire
+    $nxdomain ; NXDOMAIN ttl
 )
 
 '''

--- a/tests/test_provider_octodns_bind.py
+++ b/tests/test_provider_octodns_bind.py
@@ -268,7 +268,7 @@ cname       42 IN CNAME    target.unit.tests.
             txt = Record.new(
                 desired,
                 'txt',
-                {'type': 'TXT', 'ttl': 45, 'value': 'hello world'},
+                {'type': 'TXT', 'ttl': 45, 'value': 'hello " world'},
             )
             desired.add_record(txt)
 
@@ -288,7 +288,7 @@ cname       42 IN CNAME    target.unit.tests.
 
 @         43 IN NS       ns1.unit.tests.
           43 IN NS       ns2.unit.tests.
-txt       45 IN TXT      "hello world"
+txt       45 IN TXT      "hello \\" world"
 ''',
                     fh.read(),
                 )

--- a/tests/test_provider_octodns_bind.py
+++ b/tests/test_provider_octodns_bind.py
@@ -3,8 +3,9 @@
 #
 
 import socket
-from os.path import exists
-from shutil import copyfile
+from os.path import exists, join
+from shutil import copyfile, rmtree
+from tempfile import mkdtemp
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -12,7 +13,8 @@ import dns.resolver
 import dns.zone
 from dns.exception import DNSException
 
-from octodns.record import Record, Rr, ValidationError
+from octodns.provider.plan import Plan
+from octodns.record import Create, Record, Rr, ValidationError
 from octodns.zone import Zone
 
 from octodns_bind import (
@@ -20,10 +22,26 @@ from octodns_bind import (
     AxfrSourceZoneTransferFailed,
     Rfc2136Provider,
     Rfc2136ProviderUpdateFailed,
+    ZoneFileProvider,
     ZoneFileSource,
     ZoneFileSourceLoadFailure,
     ZoneFileSourceNotFound,
 )
+
+
+class TemporaryDirectory(object):
+    def __init__(self, delete_on_exit=True):
+        self.delete_on_exit = delete_on_exit
+
+    def __enter__(self):
+        self.dirname = mkdtemp()
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        if self.delete_on_exit:
+            rmtree(self.dirname)
+        else:
+            raise Exception(self.dirname)
 
 
 class TestAxfrSource(TestCase):
@@ -159,6 +177,209 @@ class TestZoneFileSource(TestCase):
         self.assertEqual(
             ['2.0.192.in-addr.arpa.', 'unit.tests.'], list(source.list_zones())
         )
+
+    @patch('octodns_bind.ZoneFileProvider._serial')
+    def test_apply(self, serial_mock):
+        serial_mock.side_effect = [424344, 454647]
+
+        with TemporaryDirectory() as td:
+            provider = ZoneFileProvider('target', td.dirname)
+
+            # no root NS
+            desired = Zone('unit.tests.', [])
+
+            # populate as a target, shouldn't find anything, file wouldn't even
+            # exist
+            provider.populate(desired, target=True)
+            self.assertEqual(0, len(desired.records))
+
+            cname = Record.new(
+                desired,
+                'cname',
+                {'type': 'CNAME', 'ttl': 42, 'value': 'target.unit.tests.'},
+            )
+            desired.add_record(cname)
+
+            changes = [Create(cname)]
+            plan = Plan(None, desired, changes, True)
+            provider._apply(plan)
+
+            with open(join(td.dirname, 'unit.tests.')) as fh:
+                self.assertEqual(
+                    '''$ORIGIN unit.tests.
+
+@ 3600 IN SOA ns.unit.tests. webmaster.unit.tests. (
+    424344 ; Serial
+    3600       ; Refresh (1 hour)
+    600        ; Retry (10 minutes)
+    604800     ; Expire (1 week)
+    3600       ; NXDOMAIN ttl (1 hour)
+)
+
+cname       42 IN CNAME    target.unit.tests.
+''',
+                    fh.read(),
+                )
+
+            # add a subdirectory
+            provider.directory += '/subdir'
+
+            # with a NS this time
+            ns = Record.new(
+                desired,
+                '',
+                {
+                    'type': 'NS',
+                    'ttl': 43,
+                    'values': ('ns1.unit.tests.', 'ns2.unit.tests.'),
+                },
+            )
+            desired.add_record(ns)
+            # and a second record with the same name (apex)
+            a = Record.new(
+                desired, '', {'type': 'A', 'ttl': 44, 'value': '1.2.3.4'}
+            )
+            desired.add_record(a)
+
+            plan.changes = [Create(a), Create(ns)] + plan.changes
+            provider._apply(plan)
+
+            with open(join(td.dirname, 'subdir', 'unit.tests.')) as fh:
+                self.assertEqual(
+                    '''$ORIGIN unit.tests.
+
+@ 3600 IN SOA ns1.unit.tests. webmaster.unit.tests. (
+    454647 ; Serial
+    3600       ; Refresh (1 hour)
+    600        ; Retry (10 minutes)
+    604800     ; Expire (1 week)
+    3600       ; NXDOMAIN ttl (1 hour)
+)
+
+@           44 IN A        1.2.3.4
+            43 IN NS       ns1.unit.tests.
+            43 IN NS       ns2.unit.tests.
+cname       42 IN CNAME    target.unit.tests.
+''',
+                    fh.read(),
+                )
+
+    def test_primary_nameserver(self):
+        # no records (thus no root NS records) we get the placeholder
+        self.assertEqual(
+            'ns.unit.tests.', self.source._primary_nameserver('unit.tests.', [])
+        )
+
+        class FakeNsRecord:
+            def __init__(self, name, values):
+                self.name = name
+                self.values = values
+                self._type = 'NS'
+
+        # has non-root NS record, placeholder
+        self.assertEqual(
+            'ns.unit.tests.',
+            self.source._primary_nameserver(
+                'unit.tests.', [FakeNsRecord('not-root', ['xx.unit.tests.'])]
+            ),
+        )
+
+        # has root NS record
+        self.assertEqual(
+            'ns1.unit.tests.',
+            self.source._primary_nameserver(
+                'unit.tests.',
+                [
+                    FakeNsRecord('not-root', ['xx.unit.tests.']),
+                    FakeNsRecord('', ['ns1.unit.tests.', 'ns2.unit.tests.']),
+                ],
+            ),
+        )
+
+    def test_hostmaster_email(self):
+        # default constructed
+        self.assertEqual(
+            'webmaster.unit.tests.',
+            self.source._hostmaster_email('unit.tests.'),
+        )
+
+        # overridden just username
+        source = ZoneFileProvider('test', '.', hostmaster_email='altusername')
+        self.assertEqual(
+            'altusername.unit.tests.', source._hostmaster_email('unit.tests.')
+        )
+
+        # overridden username with .
+        source = ZoneFileProvider('test', '.', hostmaster_email='alt.username')
+        self.assertEqual(
+            'alt\\.username.other.tests.',
+            source._hostmaster_email('other.tests.'),
+        )
+
+        # overridden full email addr
+        source = ZoneFileProvider(
+            'test', '.', hostmaster_email='root@some.com.'
+        )
+        self.assertEqual(
+            'root.some.com.', source._hostmaster_email('ignored.tests.')
+        )
+
+        # overridden full email addr no trailing .
+        source = ZoneFileProvider('test', '.', hostmaster_email='root@some.com')
+        self.assertEqual(
+            'root.some.com', source._hostmaster_email('ignored.tests.')
+        )
+
+    def test_longest_name(self):
+        # make sure empty doesn't blow up and we get 0
+        self.assertEqual(0, self.source._longest_name([]))
+
+        class FakeRecord:
+            def __init__(self, name):
+                self.name = name
+
+        self.assertEqual(
+            4,
+            self.source._longest_name(
+                [
+                    FakeRecord(''),
+                    FakeRecord('1'),
+                    FakeRecord('12'),
+                    FakeRecord('123'),
+                    FakeRecord('1234'),
+                ]
+            ),
+        )
+
+    @patch('octodns_bind.ZoneFileProvider._now')
+    def test_serial(self, now_mock):
+        class FakeDatetime:
+            def __init__(self, timestamp):
+                self._timestamp = timestamp
+
+            def timestamp(self):
+                return self._timestamp
+
+        now_mock.side_effect = [
+            # simple
+            FakeDatetime(42),
+            # real
+            FakeDatetime(1694231210),
+            # max
+            FakeDatetime(2147483647),
+            # max + 1
+            FakeDatetime(2147483647 + 1),
+            # max + 2
+            FakeDatetime(2147483647 + 2),
+        ]
+        self.assertEqual(42, self.source._serial())
+        self.assertEqual(1694231210, self.source._serial())
+        self.assertEqual(0, self.source._serial())
+        self.assertEqual(1, self.source._serial())
+
+    def test_now(self):
+        # smoke test
+        self.assertTrue(self.source._now())
 
 
 class TestRfc2136Provider(TestCase):

--- a/tests/test_provider_octodns_bind.py
+++ b/tests/test_provider_octodns_bind.py
@@ -210,10 +210,10 @@ class TestZoneFileSource(TestCase):
 
 @ 3600 IN SOA ns.unit.tests. webmaster.unit.tests. (
     424344 ; Serial
-    3600       ; Refresh (1 hour)
-    600        ; Retry (10 minutes)
-    604800     ; Expire (1 week)
-    3600       ; NXDOMAIN ttl (1 hour)
+    3600 ; Refresh (1 hour)
+    600 ; Retry (10 minutes)
+    604800 ; Expire (1 week)
+    3600 ; NXDOMAIN ttl (1 hour)
 )
 
 cname       42 IN CNAME    target.unit.tests.
@@ -250,10 +250,10 @@ cname       42 IN CNAME    target.unit.tests.
 
 @ 3600 IN SOA ns1.unit.tests. webmaster.unit.tests. (
     454647 ; Serial
-    3600       ; Refresh (1 hour)
-    600        ; Retry (10 minutes)
-    604800     ; Expire (1 week)
-    3600       ; NXDOMAIN ttl (1 hour)
+    3600 ; Refresh (1 hour)
+    600 ; Retry (10 minutes)
+    604800 ; Expire (1 week)
+    3600 ; NXDOMAIN ttl (1 hour)
 )
 
 @           44 IN A        1.2.3.4
@@ -272,6 +272,12 @@ cname       42 IN CNAME    target.unit.tests.
             )
             desired.add_record(txt)
 
+            # test out customizing the SOA details
+            provider.refresh = 3601
+            provider.retry = 601
+            provider.expire = 604801
+            provider.nxdomain = 3601
+
             plan.changes = [Create(txt), Create(ns)]
             provider._apply(plan)
             with open(join(td.dirname, 'subdir', 'unit.tests.')) as fh:
@@ -280,10 +286,10 @@ cname       42 IN CNAME    target.unit.tests.
 
 @ 3600 IN SOA ns1.unit.tests. webmaster.unit.tests. (
     484950 ; Serial
-    3600       ; Refresh (1 hour)
-    600        ; Retry (10 minutes)
-    604800     ; Expire (1 week)
-    3600       ; NXDOMAIN ttl (1 hour)
+    3601 ; Refresh (1 hour)
+    601 ; Retry (10 minutes)
+    604801 ; Expire (1 week)
+    3601 ; NXDOMAIN ttl (1 hour)
 )
 
 @         43 IN NS       ns1.unit.tests.

--- a/tests/test_provider_octodns_bind.py
+++ b/tests/test_provider_octodns_bind.py
@@ -273,6 +273,7 @@ cname       42 IN CNAME    target.unit.tests.
             desired.add_record(txt)
 
             # test out customizing the SOA details
+            provider.default_ttl = 3602
             provider.refresh = 3601
             provider.retry = 601
             provider.expire = 604801
@@ -284,7 +285,7 @@ cname       42 IN CNAME    target.unit.tests.
                 self.assertEqual(
                     '''$ORIGIN unit.tests.
 
-@ 3600 IN SOA ns1.unit.tests. webmaster.unit.tests. (
+@ 3602 IN SOA ns1.unit.tests. webmaster.unit.tests. (
     484950 ; Serial
     3601 ; Refresh (1 hour)
     601 ; Retry (10 minutes)

--- a/tests/test_provider_octodns_bind.py
+++ b/tests/test_provider_octodns_bind.py
@@ -210,10 +210,10 @@ class TestZoneFileSource(TestCase):
 
 @ 3600 IN SOA ns.unit.tests. webmaster.unit.tests. (
     424344 ; Serial
-    3600 ; Refresh (1 hour)
-    600 ; Retry (10 minutes)
-    604800 ; Expire (1 week)
-    3600 ; NXDOMAIN ttl (1 hour)
+    3600 ; Refresh
+    600 ; Retry
+    604800 ; Expire
+    3600 ; NXDOMAIN ttl
 )
 
 cname       42 IN CNAME    target.unit.tests.
@@ -250,10 +250,10 @@ cname       42 IN CNAME    target.unit.tests.
 
 @ 3600 IN SOA ns1.unit.tests. webmaster.unit.tests. (
     454647 ; Serial
-    3600 ; Refresh (1 hour)
-    600 ; Retry (10 minutes)
-    604800 ; Expire (1 week)
-    3600 ; NXDOMAIN ttl (1 hour)
+    3600 ; Refresh
+    600 ; Retry
+    604800 ; Expire
+    3600 ; NXDOMAIN ttl
 )
 
 @           44 IN A        1.2.3.4
@@ -287,10 +287,10 @@ cname       42 IN CNAME    target.unit.tests.
 
 @ 3602 IN SOA ns1.unit.tests. webmaster.unit.tests. (
     484950 ; Serial
-    3601 ; Refresh (1 hour)
-    601 ; Retry (10 minutes)
-    604801 ; Expire (1 week)
-    3601 ; NXDOMAIN ttl (1 hour)
+    3601 ; Refresh
+    601 ; Retry
+    604801 ; Expire
+    3601 ; NXDOMAIN ttl
 )
 
 @         43 IN NS       ns1.unit.tests.


### PR DESCRIPTION
Support for writing zone files out to disk, full read/write provider. Similar to YamlProvider all records are written out each time, i.e. when in `target` mode the provider assumes the are no existing records. 

```
(env) coho:octodns-bind ross$ cat /tmp/zonefile/unit.tests.
$ORIGIN unit.tests.

@ 3600 IN SOA ns1.unit.tests. webmaster.unit.tests. (
    1694233526 ; Serial
    3600       ; Refresh (1 hour)
    600        ; Retry (10 minutes)
    604800     ; Expire (1 week)
    3600       ; NXDOMAIN ttl (1 hour)
)

@                 300 IN A        1.2.3.4
                  300 IN A        1.2.3.5
                 3600 IN NS       ns1.unit.tests.
                 3600 IN NS       ns2.unit.tests.
                  600 IN SSHFP    1 1 7491973e5f8b39d5327cd4e08bc81b05f7710b49
                  600 IN SSHFP    1 1 bf6b6825d2977c511a475bbefb88aad54a92ac73
_25._tcp.mx1     3600 IN TLSA     3 1 1 8a9a70596e869bed72c69d97a8895dfa
_25._tcp.mx2     3600 IN TLSA     3 1 1 c164b2c3f36d068d42a6138e446152f568615f28c69bd96a73e354cac88ed00c
_imap._tcp        600 IN SRV      0 0 0 .
_pop3._tcp        600 IN SRV      0 0 0 .
_srv._tcp         600 IN SRV      10 20 30 foo-1.unit.tests.
                  600 IN SRV      10 20 30 foo-2.unit.tests.
aaaa              600 IN AAAA     2601:644:500:e210:62f8:1dff:feb8:947a
caa              1800 IN CAA      0 iodef "mailto:admin@unit.tests"
                 1800 IN CAA      0 issue "ca.unit.tests"
cname             300 IN CNAME    unit.tests.
included          300 IN CNAME    unit.tests.
loc               300 IN LOC      31 58 52.1 S 115 49 11.7 E 20.0m 10.0m 10.0m 2.0m
                  300 IN LOC      53 14 10.0 N 2 18 26.0 W 20.0m 10.0m 1000.0m 2.0m
mx                300 IN MX       10 smtp-4.unit.tests.
                  300 IN MX       20 smtp-2.unit.tests.
                  300 IN MX       30 smtp-3.unit.tests.
                  300 IN MX       40 smtp-1.unit.tests.
txt               600 IN TXT      "Bah bah black sheep"
                  600 IN TXT      "have you any wool."
                  600 IN TXT      "v=DKIM1\;k=rsa\;s=email\;h=sha256\;p=A/kinda+of/long/string+with+numb3rs"
under            3600 IN NS       ns1.unit.tests.
                 3600 IN NS       ns2.unit.tests.
www               300 IN A        2.2.3.6
wwww.sub          300 IN A        2.2.3.6
```

/cc Fixes https://github.com/octodns/octodns-bind/issues/40 @kabenin 
/cc @yzguy for :eyes: