### PR TITLE
v0.0.5 version bump & changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.0.5 - 2023-??-?? - ???
+## v0.0.5 - 2023-09-12 - Write that which we can read
 
 - ZoneFileProvider, full support writing zone files out to disk
 - ZoneFileSource.list_zones added to support dynamic zone config

--- a/octodns_bind/__init__.py
+++ b/octodns_bind/__init__.py
@@ -22,7 +22,7 @@ from octodns.provider.base import BaseProvider
 from octodns.record import Create, Record, Rr, Update
 from octodns.source.base import BaseSource
 
-__VERSION__ = '0.0.4'
+__VERSION__ = '0.0.5'
 
 
 class RfcPopulate:


### PR DESCRIPTION
## v0.0.5 - 2023-09-12 - Write that which we can read

- ZoneFileProvider, full support writing zone files out to disk
- ZoneFileSource.list_zones added to support dynamic zone config