### PR TITLE
ZoneFileProvider populate returns false, when used as a target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.0.6 - 2023-??-?? - ???
+
+- `ZoneFileProvider` assumes zone files don't exist when used as a
+  target. This avoids the need to `--force` root NS changes when
+  re-writing files.
+
 ## v0.0.5 - 2023-09-12 - Write that which we can read
 
 - ZoneFileProvider, full support writing zone files out to disk

--- a/octodns_bind/__init__.py
+++ b/octodns_bind/__init__.py
@@ -66,11 +66,6 @@ class RfcPopulate:
             'populate:   found %s records', len(zone.records) - before
         )
 
-        if target:
-            # When acting as a target we ignore any existing records so that we
-            # create a completely new copy
-            return False
-
         return self.zone_exists(zone)
 
 
@@ -179,6 +174,15 @@ class ZoneFileProvider(RfcPopulate, BaseProvider):
                 if n > 0:
                     filename = filename[:-n]
                 yield filename
+
+    def populate(self, zone, target=False, lenient=False):
+        ret = super().populate(zone, target, lenient)
+
+        if target:
+            # When acting as a target we ignore any existing records so that we
+            # create a completely new copy
+            return False
+        return ret
 
     def _load_zone_file(self, zone_name, target):
         if target:

--- a/octodns_bind/__init__.py
+++ b/octodns_bind/__init__.py
@@ -66,6 +66,11 @@ class RfcPopulate:
             'populate:   found %s records', len(zone.records) - before
         )
 
+        if target:
+            # When acting as a target we ignore any existing records so that we
+            # create a completely new copy
+            return False
+
         return self.zone_exists(zone)
 
 

--- a/octodns_bind/__init__.py
+++ b/octodns_bind/__init__.py
@@ -66,7 +66,7 @@ class RfcPopulate:
             'populate:   found %s records', len(zone.records) - before
         )
 
-        return self.zone_exists(zone)
+        return self.zone_exists(zone, target)
 
 
 class ZoneFileSourceException(Exception):
@@ -175,15 +175,6 @@ class ZoneFileProvider(RfcPopulate, BaseProvider):
                     filename = filename[:-n]
                 yield filename
 
-    def populate(self, zone, target=False, lenient=False):
-        ret = super().populate(zone, target, lenient)
-
-        if target:
-            # When acting as a target we ignore any existing records so that we
-            # create a completely new copy
-            return False
-        return ret
-
     def _load_zone_file(self, zone_name, target):
         if target:
             # if we're in target mode we assume nothing exists b/c we recreate
@@ -208,7 +199,12 @@ class ZoneFileProvider(RfcPopulate, BaseProvider):
 
         return z
 
-    def zone_exists(self, zone):
+    def zone_exists(self, zone, target=False):
+        if target:
+            # When acting as a target we ignore any existing records so that we
+            # create a completely new copy
+            return False
+
         zone_filename = f'{zone.name[:-1]}{self.file_extension}'
         return exists(join(self.directory, zone_filename))
 
@@ -404,7 +400,7 @@ class AxfrPopulate(RfcPopulate):
             params['keyalgorithm'] = self.key_algorithm
         return params
 
-    def zone_exists(self, zone):
+    def zone_exists(self, zone, target=False):
         # We can't create them so they have to already exist
         return True
 


### PR DESCRIPTION
ZoneFileProvider behaves the same way YamlProvider does. Whenever used as a target, populate returns False, so Plan's raise_if_unsafe does not raise RootNsChange.