### PR TITLE
Fix list_zones behavior with file_extension=''

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - `ZoneFileProvider` assumes zone files don't exist when used as a
   target. This avoids the need to `--force` root NS changes when
   re-writing files.
+- Fix list_zones behavior with file_extension=''
 
 ## v0.0.5 - 2023-09-12 - Write that which we can read
 

--- a/octodns_bind/__init__.py
+++ b/octodns_bind/__init__.py
@@ -169,12 +169,12 @@ class ZoneFileProvider(RfcPopulate, BaseProvider):
         self._zone_records = {}
 
     def list_zones(self):
-        n = len(self.file_extension) - 1
+        n = len(self.file_extension)
         for filename in sorted(listdir(self.directory)):
             if filename.endswith(self.file_extension):
                 if n > 0:
                     filename = filename[:-n]
-                yield filename
+                yield f'{filename}.'
 
     def _load_zone_file(self, zone_name, target):
         if target:

--- a/tests/test_provider_octodns_bind.py
+++ b/tests/test_provider_octodns_bind.py
@@ -167,15 +167,27 @@ class TestZoneFileSource(TestCase):
         self.assertEqual(12, len(invalid.records))
 
     def test_list_zones(self):
-        source = ZoneFileSource('test', './tests/zones', file_extension='.tst')
+        source = ZoneFileSource('test', './tests/zones')
+        self.assertEqual(
+            ['2.0.192.in-addr.arpa.', 'unit.tests.'], list(source.list_zones())
+        )
+
+    @patch('octodns_bind.listdir')
+    def test_list_zones_empty_extension(self, listdir_mock):
+        listdir_mock.side_effect = [
+            ('invalid.records', 'invalid.zone', 'unit.tests')
+        ]
+        source = ZoneFileSource('test', './tests/zones', file_extension='')
         self.assertEqual(
             ['invalid.records.', 'invalid.zone.', 'unit.tests.'],
             list(source.list_zones()),
         )
 
-        source = ZoneFileSource('test', './tests/zones')
+    def test_list_zones_custon_extension(self):
+        source = ZoneFileSource('test', './tests/zones', file_extension='.tst')
         self.assertEqual(
-            ['2.0.192.in-addr.arpa.', 'unit.tests.'], list(source.list_zones())
+            ['invalid.records.', 'invalid.zone.', 'unit.tests.'],
+            list(source.list_zones()),
         )
 
     @patch('octodns_bind.ZoneFileProvider._serial')


### PR DESCRIPTION
Rework list_zones to handle file_extension='', always remove and re-add the `.`

/cc Fixes https://github.com/octodns/octodns-bind/pull/41#issuecomment-1826793753 @blop