### PR TITLE
Address datetime.utcnow deprecation in py 3.12

### DIFF
--- a/octodns_bind/__init__.py
+++ b/octodns_bind/__init__.py
@@ -22,6 +22,14 @@ from octodns.provider.base import BaseProvider
 from octodns.record import Create, Record, Rr, Update
 from octodns.source.base import BaseSource
 
+# TODO: remove once we require python >= 3.11
+try:  # pragma: no cover
+    from datetime import UTC
+except ImportError:  # pragma: no cover
+    from datetime import timedelta, timezone
+
+    UTC = timezone(timedelta())
+
 # TODO: remove __VERSION__ with the next major version release
 __version__ = __VERSION__ = '0.0.5'
 
@@ -252,7 +260,7 @@ class ZoneFileProvider(RfcPopulate, BaseProvider):
             return 0
 
     def _now(self):
-        return datetime.utcnow()
+        return datetime.now(UTC)
 
     def _serial(self):
         # things wrap/reset at max int

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,4 +11,7 @@ line_length=80
 sections="FUTURE,STDLIB,THIRDPARTY,OCTODNS,FIRSTPARTY,LOCALFOLDER"
 
 [tool.pytest.ini_options]
+filterwarnings = [
+    'error',
+]
 pythonpath = "."


### PR DESCRIPTION
Use now(UTC) with a backwards compatible way of getting UTC prior or py 3.11.

/cc https://github.com/octodns/octodns/pull/1108