### PR TITLE
Version 0.0.6 version bump & changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.0.6 - 2023-??-?? - ???
+## v0.0.6 - 2024-01-30 - Known your zones
 
 - `ZoneFileProvider` assumes zone files don't exist when used as a
   target. This avoids the need to `--force` root NS changes when

--- a/octodns_bind/__init__.py
+++ b/octodns_bind/__init__.py
@@ -31,7 +31,7 @@ except ImportError:  # pragma: no cover
     UTC = timezone(timedelta())
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '0.0.5'
+__version__ = __VERSION__ = '0.0.6'
 
 
 class RfcPopulate:


### PR DESCRIPTION
## v0.0.6 - 2024-01-30 - Known your zones

- `ZoneFileProvider` assumes zone files don't exist when used as a
  target. This avoids the need to `--force` root NS changes when
  re-writing files.
- Fix list_zones behavior with file_extension=''