### PR TITLE
replace rndc-confgen by tsig-keygen

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ providers:
 Example Bind9 config to enable AXFR and RFC 2136
 
 ```
-# generated with rndc-confgen
-key octodns.exxampled.com. {
+# generated with: $ tsig-keygen octodns.exxampled.com.
+key "octodns.exxampled.com." {
   algorithm hmac-sha256;
   secret "vZew5TtZLTZKTCl00xliGt+1zzsuLWQWFz48bRbPnZU=";
 };


### PR DESCRIPTION
While `rndc-confgen` creates TSIG keys, there has now for years been a dedicated usitlity for doing so: `tsig-keygen`