### PR TITLE
Release 0.0.7 version bump and changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.0.7 - 2025-??-?? - ???
+## v0.0.7 - 2025-01-17 - Back to the base
 
 - Add support for Provider base class parameters
 

--- a/octodns_bind/__init__.py
+++ b/octodns_bind/__init__.py
@@ -31,7 +31,7 @@ except ImportError:  # pragma: no cover
     UTC = timezone(timedelta())
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '0.0.6'
+__version__ = __VERSION__ = '0.0.7'
 
 
 class RfcPopulate:


### PR DESCRIPTION
## v0.0.7 - 2025-01-17 - Back to the base

- Add support for Provider base class parameters