### PR TITLE
split TXT/SPF records longer than 255 characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.0.8 - 20??-??-?? - ???
+
+- Split long TXT values using chunked_value before writing
+
 ## v0.0.7 - 2025-01-17 - Back to the base
 
 - Add support for Provider base class parameters

--- a/octodns_bind/__init__.py
+++ b/octodns_bind/__init__.py
@@ -320,9 +320,8 @@ class ZoneFileProvider(RfcPopulate, BaseProvider):
                 for value in values:
                     value = value.rdata_text
                     if record._type in ('SPF', 'TXT'):
-                        # TXT values need to be quoted
-                        value = value.replace('"', '\\"')
-                        value = f'"{value}"'
+                        # TXT values need to be quoted and split if longer than 255 characters
+                        value = record.chunked_value(value)
                     name = '@' if record.name == '' else record.name
                     if name == prev_name:
                         name = ''


### PR DESCRIPTION
Ensure that TXT and SPF records exceeding 255 characters are properly split into multiple quoted strings to comply with DNS specifications. Added test_split_long_txt_record to test this behaviour

Closes #65