### PR TITLE
UTF-8 name support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## v0.0.8 - 20??-??-?? - ???
 
 - Split long TXT values using chunked_value before writing
+- Correctly handle utf-8 names and zones by writing out idna encoded values and
+  using idna encoded filenames
 
 ## v0.0.7 - 2025-01-17 - Back to the base
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "2.4"  # optional since v1.27.0
-
 services:
   bind9:
     # https://hub.docker.com/r/internetsystemsconsortium/bind9

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,9 @@ services:
       - type: bind
         source: ./docker/var/lib/bind/db.exxampled.com
         target: /var/lib/bind/db.exxampled.com
+      - type: bind
+        source: ./docker/var/lib/bind/db.xn--fa-hia.de.
+        target: /var/lib/bind/db.xn--fa-hia.de.
 networks:
   dns:
     enable_ipv6: true

--- a/docker/etc/bind/named.conf
+++ b/docker/etc/bind/named.conf
@@ -27,6 +27,14 @@ zone "exxampled.com." {
   allow-update { key octodns.exxampled.com.; };
 };
 
+zone "xn--fa-hia.de." {
+  type master;
+  file "/var/lib/bind/db.xn--fa-hia.de.";
+  notify explicit;
+  allow-transfer { key octodns.exxampled.com.; };
+  allow-update { key octodns.exxampled.com.; };
+};
+
 # logging
 logging {
   channel stdout {

--- a/docker/var/lib/bind/db.xn--fa-hia.de.
+++ b/docker/var/lib/bind/db.xn--fa-hia.de.
@@ -1,0 +1,18 @@
+$ORIGIN xn--fa-hia.de.
+
+; Zone name: faß.de. / xn--fa-hia.de.
+@ 3600 IN SOA ns1.xn--fa-hia.de. webmaster.xn--fa-hia.de. (
+    1742254963 ; Serial
+    3600 ; Refresh
+    600 ; Retry
+    604800 ; Expire
+    3600 ; NXDOMAIN ttl
+)
+
+; Name: faß.de.
+@                  86400 IN MX       10 mx.xn--fa-hia.de.
+                   86400 IN NS       ns1.xn--fa-hia.de.
+mx                 86400 IN A        127.0.0.1
+ns1                86400 IN A        127.0.0.1
+; Name: déjà-vu.faß.de.
+xn--dj-vu-sqa5d    86400 IN A        127.0.0.1

--- a/octodns_bind/__init__.py
+++ b/octodns_bind/__init__.py
@@ -270,7 +270,6 @@ class ZoneFileProvider(RfcPopulate, BaseProvider):
 
     def _apply(self, plan):
         desired = plan.desired
-        name = desired.decoded_name
 
         if not isdir(self.directory):
             makedirs(self.directory)
@@ -278,12 +277,15 @@ class ZoneFileProvider(RfcPopulate, BaseProvider):
         records = sorted(c.record for c in plan.changes)
         longest_name = self._longest_name(records)
 
+        name = desired.name
         filename = join(self.directory, f'{name[:-1]}{self.file_extension}')
         with open(filename, 'w') as fh:
+            fh.write(f'$ORIGIN {name}\n\n')
+            utf8_name = desired.decoded_name
+            if name != utf8_name:
+                fh.write(f'; Zone name: {utf8_name}\n')
             template = Template(
-                '''$$ORIGIN $zone_name
-
-@ $default_ttl IN SOA $primary_nameserver $hostmaster_email (
+                '''@ $default_ttl IN SOA $primary_nameserver $hostmaster_email (
     $serial ; Serial
     $refresh ; Refresh
     $retry ; Retry
@@ -318,15 +320,18 @@ class ZoneFileProvider(RfcPopulate, BaseProvider):
                 except AttributeError:
                     values = [record.value]
                 for value in values:
-                    value = value.rdata_text
-                    if record._type in ('SPF', 'TXT'):
-                        # TXT values need to be quoted and split if longer than 255 characters
-                        value = record.chunked_value(value)
                     name = '@' if record.name == '' else record.name
                     if name == prev_name:
                         name = ''
                     else:
                         prev_name = name
+                        if name != record.decoded_name:
+                            # idna encoded, add a comment with the utf8 version
+                            fh.write(f'; Name: {record.decoded_fqdn}\n')
+                    value = value.rdata_text
+                    if record._type in ('SPF', 'TXT'):
+                        # TXT values need to be quoted and split if longer than 255 characters
+                        value = record.chunked_value(value)
                     fh.write(
                         f'{name:<{longest_name}} {record.ttl:8d} IN {record._type:<8} {value}\n'
                     )

--- a/tests/test_provider_octodns_bind.py
+++ b/tests/test_provider_octodns_bind.py
@@ -293,6 +293,7 @@ cname       42 IN CNAME    target.unit.tests.
     3600 ; NXDOMAIN ttl
 )
 
+; Name: unit.tests.
 @           44 IN A        1.2.3.4
             43 IN NS       ns1.unit.tests.
             43 IN NS       ns2.unit.tests.
@@ -330,9 +331,66 @@ cname       42 IN CNAME    target.unit.tests.
     3601 ; NXDOMAIN ttl
 )
 
+; Name: unit.tests.
 @         43 IN NS       ns1.unit.tests.
           43 IN NS       ns2.unit.tests.
 txt       45 IN TXT      "hello \\" world"
+''',
+                    fh.read(),
+                )
+
+    @patch('octodns_bind.ZoneFileProvider._serial')
+    def test_utf8(self, serial_mock):
+        serial_mock.side_effect = [424344]
+
+        with TemporaryDirectory() as td:
+            provider = ZoneFileProvider('target', td.dirname)
+
+            desired = Zone('faß.de.', [])
+
+            ns = Record.new(
+                desired,
+                '',
+                {
+                    'type': 'NS',
+                    'ttl': 43,
+                    'values': ('ns1.xn--fa-hia.de.', 'ns2.xn--fa-hia.de.'),
+                },
+            )
+            desired.add_record(ns)
+
+            # utf-8 zone name
+            txt = Record.new(
+                desired,
+                # utf-8 name
+                'déjà-vu',
+                {'type': 'TXT', 'ttl': 45, 'value': 'hello world'},
+            )
+            desired.add_record(txt)
+
+            changes = [Create(txt), Create(ns)]
+            plan = Plan(None, desired, changes, True)
+            provider._apply(plan)
+            # file written out with idna name
+            with open(join(td.dirname, 'xn--fa-hia.de.')) as fh:
+                self.maxDiff = 99999
+                self.assertEqual(
+                    '''$ORIGIN xn--fa-hia.de.
+
+; Zone name: faß.de.
+@ 3600 IN SOA ns1.xn--fa-hia.de. webmaster.xn--fa-hia.de. (
+    424344 ; Serial
+    3600 ; Refresh
+    600 ; Retry
+    604800 ; Expire
+    3600 ; NXDOMAIN ttl
+)
+
+; Name: faß.de.
+@                     43 IN NS       ns1.xn--fa-hia.de.
+                      43 IN NS       ns2.xn--fa-hia.de.
+; Name: déjà-vu.faß.de.
+xn--dj-vu-sqa5d       45 IN TXT      "hello world"
 ''',
                     fh.read(),
                 )


### PR DESCRIPTION
Correctly handle utf-8 names and zones by writing out idna encoded values and using idna encoded filenames

/cc Fixes https://github.com/octodns/octodns-bind/issues/68
/cc @asalmela fyi and for :eyes: