### PR TITLE
When writing RFC2317 zones, convert "/" to "-" in the filename.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v0.0.8 - 20??-??-?? - ???
 
 - Split long TXT values using chunked_value before writing
+- When writing RFC2317 zones, convert "/" to "-" in the filename.
 
 ## v0.0.7 - 2025-01-17 - Back to the base
 

--- a/octodns_bind/__init__.py
+++ b/octodns_bind/__init__.py
@@ -278,7 +278,10 @@ class ZoneFileProvider(RfcPopulate, BaseProvider):
         records = sorted(c.record for c in plan.changes)
         longest_name = self._longest_name(records)
 
-        filename = join(self.directory, f'{name[:-1]}{self.file_extension}')
+        filename = join(
+            self.directory,
+            f'{name[:-1].replace("/", "-")}{self.file_extension}',
+        )
         with open(filename, 'w') as fh:
             template = Template(
                 '''$$ORIGIN $zone_name

--- a/tests/test_provider_octodns_bind.py
+++ b/tests/test_provider_octodns_bind.py
@@ -337,6 +337,59 @@ txt       45 IN TXT      "hello \\" world"
                     fh.read(),
                 )
 
+    @patch("octodns_bind.ZoneFileProvider._serial")
+    def test_apply_rfc2317(self, serial_mock):
+        serial_mock.side_effect = [424344, 454647, 484950]
+
+        with TemporaryDirectory() as td:
+            provider = ZoneFileProvider(
+                "target", td.dirname, hostmaster_email='webmaster@unit.tests.'
+            )
+
+            # no root NS
+            desired = Zone("0/25.10.10.10.in-addr.arpa.", [])
+
+            # populate as a target, shouldn't find anything, file wouldn't even
+            # exist
+            provider.populate(desired, target=True)
+            self.assertEqual(0, len(desired.records))
+
+            ns_record = Record.new(
+                desired,
+                "",
+                {"type": "NS", "ttl": 42, "value": "ns.unit.tests."},
+            )
+            desired.add_record(ns_record)
+
+            ptr = Record.new(
+                desired,
+                "10",
+                {"type": "PTR", "ttl": 42, "value": "target.unit.tests."},
+            )
+            desired.add_record(ptr)
+
+            changes = [Create(ptr), Create(ns_record)]
+            plan = Plan(None, desired, changes, True)
+            provider._apply(plan)
+
+            with open(join(td.dirname, "0-25.10.10.10.in-addr.arpa.")) as fh:
+                self.assertEqual(
+                    """$ORIGIN 0/25.10.10.10.in-addr.arpa.
+
+@ 3600 IN SOA ns.unit.tests. webmaster.unit.tests. (
+    424344 ; Serial
+    3600 ; Refresh
+    600 ; Retry
+    604800 ; Expire
+    3600 ; NXDOMAIN ttl
+)
+
+@        42 IN NS       ns.unit.tests.
+10       42 IN PTR      target.unit.tests.
+""",
+                    fh.read(),
+                )
+
     def test_primary_nameserver(self):
         # no records (thus no root NS records) we get the placeholder
         self.assertEqual(


### PR DESCRIPTION
When trying to write RFC2317 zones, of the form e.g. *0/25.10.10.10.in-addr.arpa.*, octodns-sync fails with:
```
...
with open(filename, 'w') as fh:
^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: './test/0/25.10.10.10.in-addr.arpa.'
```

To avoid this, we replace the **/** with a **-** in the filename.