### PR TITLE
Version 1.0.0 version bump & changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.0.8 - 20??-??-?? - ???
+## v1.0.0 - 2025-04-29 - Long overdue 1.0
 
 - Split long TXT values using chunked_value before writing
 - Correctly handle utf-8 names and zones by writing out idna encoded values and

--- a/octodns_bind/__init__.py
+++ b/octodns_bind/__init__.py
@@ -31,7 +31,7 @@ except ImportError:  # pragma: no cover
     UTC = timezone(timedelta())
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '0.0.7'
+__version__ = __VERSION__ = '1.0.0'
 
 
 class RfcPopulate:


### PR DESCRIPTION
## v1.0.0 - 2025-04-29 - Long overdue 1.0

- Split long TXT values using chunked_value before writing
- Correctly handle utf-8 names and zones by writing out idna encoded values and
  using idna encoded filenames
- When writing RFC2317 zones, convert "/" to "-" in the filename.