### PR TITLE
Version 1.0.1 version bump & changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.0.1 - 2025-05-04 - Up our requirements
+
+* Require octodns >= 1.5.0
+
 ## v1.0.0 - 2025-04-29 - Long overdue 1.0
 
 - Split long TXT values using chunked_value before writing

--- a/octodns_bind/__init__.py
+++ b/octodns_bind/__init__.py
@@ -31,7 +31,7 @@ except ImportError:  # pragma: no cover
     UTC = timezone(timedelta())
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '1.0.0'
+__version__ = __VERSION__ = '1.0.1'
 
 
 class RfcPopulate:


### PR DESCRIPTION
## v1.0.1 - 2025-05-04 - Up our requirements

* Require octodns >= 1.5.0