### PR TITLE
Version 1.1.0 bump & changelog update

### DIFF
--- a/.changelog/05f3b5dc965240e7a07f71522e390fd9.md
+++ b/.changelog/05f3b5dc965240e7a07f71522e390fd9.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Use new [changelet](https://github.com/octodns/changelet) tooling

--- a/.changelog/0bce91c5cef84b0d946672db0b128c58.md
+++ b/.changelog/0bce91c5cef84b0d946672db0b128c58.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/0c766cb99c8a419aa8af6396b7ee56aa.md
+++ b/.changelog/0c766cb99c8a419aa8af6396b7ee56aa.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Run changelog check during pre-commit

--- a/.changelog/2b3a12aa3a6f44318dfcb37072feeaa4.md
+++ b/.changelog/2b3a12aa3a6f44318dfcb37072feeaa4.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Pull in the latest template changes

--- a/.changelog/3e102a01ad87421b904ea414a770b406.md
+++ b/.changelog/3e102a01ad87421b904ea414a770b406.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/41bc3f8da3c84ca9a734d0be96c589c5.md
+++ b/.changelog/41bc3f8da3c84ca9a734d0be96c589c5.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update scripts to use common.sh

--- a/.changelog/4552d6a899f7491fb032607354bb1e7d.md
+++ b/.changelog/4552d6a899f7491fb032607354bb1e7d.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/583418dd6a234c5c847cf7ab5bfd1822.md
+++ b/.changelog/583418dd6a234c5c847cf7ab5bfd1822.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-enable NAPTR record processing

--- a/.changelog/70c98b34203b43af8618b8229992ae04.md
+++ b/.changelog/70c98b34203b43af8618b8229992ae04.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/7f722301e34140f7bbf0b4126709342d.md
+++ b/.changelog/7f722301e34140f7bbf0b4126709342d.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Add JSON coverage report format

--- a/.changelog/8d5ac9f8740a4cdd9dde916a17e8ffef.md
+++ b/.changelog/8d5ac9f8740a4cdd9dde916a17e8ffef.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Switch to proviso for requirements.txt management

--- a/.changelog/aad323b656804ba8a5eb4ba640bf097a.md
+++ b/.changelog/aad323b656804ba8a5eb4ba640bf097a.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Use script/common.sh in script/update-requirements

--- a/.changelog/b4e52c6e796c490abe6db49503a3e68d.md
+++ b/.changelog/b4e52c6e796c490abe6db49503a3e68d.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements*.txt

--- a/.changelog/d022de04a0bd47b8b7e309f04e381c80.md
+++ b/.changelog/d022de04a0bd47b8b7e309f04e381c80.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Add NAPTR record support

--- a/.changelog/d89ddfcec61e4105b96ffa98e1859be6.md
+++ b/.changelog/d89ddfcec61e4105b96ffa98e1859be6.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Add HTTPS and SVCB record support

--- a/.changelog/e3df540303ef408d844e99db1adae953.md
+++ b/.changelog/e3df540303ef408d844e99db1adae953.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.1.0 - 2026-04-03
+
+Minor:
+* enable NAPTR record processing - [#101](https://github.com/octodns/octodns-bind/pull/101)
+* Add HTTPS and SVCB record support - [#93](https://github.com/octodns/octodns-bind/pull/93)
+* Add NAPTR record support - [#86](https://github.com/octodns/octodns-bind/pull/86)
+
+Patch:
+* Use new [changelet](https://github.com/octodns/changelet) tooling - [#84](https://github.com/octodns/octodns-bind/pull/84)
+
 ## v1.0.1 - 2025-05-04 - Up our requirements
 
 * Require octodns >= 1.5.0

--- a/octodns_bind/__init__.py
+++ b/octodns_bind/__init__.py
@@ -31,7 +31,7 @@ except ImportError:  # pragma: no cover
     UTC = timezone(timedelta())
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '1.0.1'
+__version__ = __VERSION__ = '1.1.0'
 
 
 class RfcPopulate:


### PR DESCRIPTION
## 1.1.0 - 2026-04-03

Minor:
* enable NAPTR record processing - [#101](https://github.com/octodns/octodns-bind/pull/101)
* Add HTTPS and SVCB record support - [#93](https://github.com/octodns/octodns-bind/pull/93)
* Add NAPTR record support - [#86](https://github.com/octodns/octodns-bind/pull/86)

Patch:
* Use new [changelet](https://github.com/octodns/changelet) tooling - [#84](https://github.com/octodns/octodns-bind/pull/84)

