### PR TITLE
Fix SRV record validation test

### DIFF
--- a/.changelog/f2ed08aa05e545d28ec4483cb07192b7.md
+++ b/.changelog/f2ed08aa05e545d28ec4483cb07192b7.md
@@ -1,0 +1,4 @@
+---
+type: none
+---
+Fix SRV record validation test

--- a/tests/test_provider_octodns_bind.py
+++ b/tests/test_provider_octodns_bind.py
@@ -156,7 +156,7 @@ class TestZoneFileSource(TestCase):
         # quotes were added to the record name 1.0.0rc1, this makes it work with
         # both version
         reason = str(ctx.exception).replace('"', '')
-        self.assertEqual(
+        self.assertIn(
             'Invalid record _invalid.invalid.records.\n  - invalid name for SRV record',
             reason,
         )


### PR DESCRIPTION
Fixes the validation test failure caused by changes to validation error message context by looking for the expected substring.

/cc https://github.com/octodns/octodns/pull/1443